### PR TITLE
Add B25 to PsrType enum to fix #3

### DIFF
--- a/entsoe_api/enums/code_bindings/psr_type.py
+++ b/entsoe_api/enums/code_bindings/psr_type.py
@@ -36,6 +36,7 @@ class PsrType(CodeBinding):
         DC_LINK (str): DC link type (code 'B22').
         SUBSTATION (str): Substation type (code 'B23').
         TRANSFORMER (str): Transformer type (code 'B24').
+        ENERGY_STORAGE (str): Storage type (code 'B25').
         ALL (str): All types of energy (code 'ALL').
     """
 
@@ -66,4 +67,5 @@ class PsrType(CodeBinding):
     DC_LINK = 'B22'
     SUBSTATION = 'B23'
     TRANSFORMER = 'B24'
+    ENERGY_STORAGE = 'B25'
     ALL = 'ALL'


### PR DESCRIPTION
## Description
This PR adds the missing `B25` code to the `PsrType` enumeration. 
This prevents a `ValueError` when fetching generation data for certain bidding zones like France.

## Linked Issues
Closes #3 
